### PR TITLE
handle parameters

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"log"
@@ -22,6 +23,11 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/kr/pty"
 )
+
+type InitMessage struct {
+	Params    string `json:"Params,omitempty"`
+	AuthToken string `json:"AuthToken,omitempty"`
+}
 
 type App struct {
 	command []string
@@ -49,6 +55,7 @@ type Options struct {
 	EnableReconnect bool                   `hcl:"enable_reconnect"`
 	ReconnectTime   int                    `hcl:"reconnect_time"`
 	Once            bool                   `hcl:"once"`
+	PermitArguments bool                   `hcl:"permit-arguments"`
 	Preferences     map[string]interface{} `hcl:"preferences"`
 }
 
@@ -222,14 +229,42 @@ func (app *App) handleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, initMessage, err := conn.ReadMessage()
-	if err != nil || string(initMessage) != app.options.Credential {
+	_, stream, err := conn.ReadMessage()
+	if err != nil {
 		log.Print("Failed to authenticate websocket connection")
 		conn.Close()
 		return
 	}
+	var init InitMessage
 
-	cmd := exec.Command(app.command[0], app.command[1:]...)
+	err = json.Unmarshal(stream, &init)
+	if err != nil {
+		log.Printf("Failed to parse init message %v", err)
+		conn.Close()
+		return
+	}
+	if init.AuthToken != app.options.Credential {
+		log.Print("Failed to authenticate websocket connection")
+		conn.Close()
+		return
+	}
+	argv := app.command[1:]
+	if app.options.PermitArguments {
+		if init.Params == "" {
+			init.Params = "?"
+		}
+		query, err := url.Parse(init.Params)
+		if err != nil {
+			log.Print("Failed to parse parameters")
+			conn.Close()
+			return
+		}
+		params := query.Query().Get("Params")
+		if params != "" {
+			argv = append(argv, params)
+		}
+	}
+	cmd := exec.Command(app.command[0], argv...)
 	ptyIo, err := pty.Start(cmd)
 	if err != nil {
 		log.Print("Failed to execute command")

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 		flag{"reconnect", "", "Enable reconnection"},
 		flag{"reconnect-time", "", "Time to reconnect"},
 		flag{"once", "", "Accept only one client and exit on disconnection"},
+		flag{"permit-arguments", "", "Allow to send arguments"},
 	}
 
 	mappingHint := map[string]string{

--- a/resources/gotty.js
+++ b/resources/gotty.js
@@ -1,5 +1,6 @@
 (function() {
     var httpsEnabled = window.location.protocol == "https:";
+    var args = window.location.search;
     var url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + window.location.pathname + 'ws';
     var protocols = ["gotty"];
     var autoReconnect = -1;
@@ -12,8 +13,7 @@
         var pingTimer;
 
         ws.onopen = function(event) {
-            ws.send(gotty_auth_token);
-
+            ws.send(JSON.stringify({ Params: args, AuthToken: gotty_auth_token,}));
             pingTimer = setInterval(sendPing, 30 * 1000, ws);
 
             hterm.defaultStorage = new lib.Storage.Local();


### PR DESCRIPTION
Hi,
I do this PR to handle parameters with the `permit-arguments` flag.

Example:

``` bash
$> gotty --permit-arguments tail -f 
```

And you can pass argument like this : `http://server.exmple.com:8080/?Params=filename`
